### PR TITLE
Dynamically install and uninstall as.hms.units() provided by the units package

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,0 +1,42 @@
+known_packages <- c(
+  "units"
+)
+
+our_methods <- c(
+  "as.hms"
+)
+
+.onLoad <- function(libname, pkgname) {
+  lapply(intersect(loadedNamespaces(), known_packages), load_known_package)
+  lapply(known_packages, function(pkgname) {
+    setHook(packageEvent(pkgname, "onLoad"), load_known_package)
+    setHook(packageEvent(pkgname, "onUnload"), unload_known_package)
+  })
+}
+
+load_known_package <- function(pkgname, ...) {
+  implemented_methods <- find_implemented_methods(getNamespace(pkgname))
+  Map(names(implemented_methods), implemented_methods, f = function(name, fun) {
+    .__S3MethodsTable__.[[name]] <- fun
+  })
+}
+
+unload_known_package <- function(pkgname, ...) {
+  implemented_method_names <- find_implemented_methods(getNamespace(pkgname))
+  Map(implemented_method_names, f = function(name) {
+    .__S3MethodsTable__.[[name]] <- NULL
+  })
+}
+
+find_implemented_method_names <- function(env) {
+  pattern <- utils::glob2rx(paste0(our_methods, "*"))
+  ls(env, all.names = TRUE, pattern = pattern)
+}
+
+find_implemented_methods <- function(env) {
+  implemented_method_names <- find_implemented_method_names(env)
+  implemented_methods <- mget(
+    implemented_method_names, env, mode = "function",
+    ifnotfound = rep(list(NULL), length(implemented_method_names)))
+  implemented_methods[!vapply(implemented_methods, is.null, logical(1L))]
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,3 +1,4 @@
+# nocov start
 known_packages <- c(
   "units"
 )
@@ -40,3 +41,4 @@ find_implemented_methods <- function(env) {
     ifnotfound = rep(list(NULL), length(implemented_method_names)))
   implemented_methods[!vapply(implemented_methods, is.null, logical(1L))]
 }
+# nocov end


### PR DESCRIPTION
Problem: The `units` package implements `as.hms.units()` but doesn't necessarily need to import the `units` package.

Solution: `units` declares `hms` as "Enhances", `hms` patches its S3 methods table when `units` is loaded or unloaded.

@hadley: PTAL; this could be described in a "vctrs" vignette; the problem of type conversion without importing will reappear.

@edzer: Would you mind adding "Enhances: hms (>= 0.2-2)" instead of edzer/units@24f1b61?
