### PR TITLE
fix as.hms.numeric for zero-length input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 - `as.hms.character()` and `parse_hms()` accept fractional seconds (#33).
 
+- `as.hms.numeric()` properly handles zero-length inputs
 
 ### hms 0.3.0.9001 (2017-04-25)
 

--- a/R/hms.R
+++ b/R/hms.R
@@ -71,7 +71,10 @@ as.hms.difftime <- function(x, ...) {
 
 #' @rdname hms
 #' @export
-as.hms.numeric <- function(x, ...) hms(seconds = x)
+as.hms.numeric <- function(x, ...) {
+  if (length(x) == 0) return(as.hms(character(0)))
+  hms(seconds = x)
+}
 
 #' @rdname hms
 #' @export


### PR DESCRIPTION
Fixes #35 

I'm sure there is a more elegant way to handle this, but this ensures that zero length inputs are handled consistently between numeric and character.