### PR TITLE
Fix formatting for times with a very small distance to the full second

### DIFF
--- a/R/arith.R
+++ b/R/arith.R
@@ -1,16 +1,20 @@
+SPLIT_SECOND_DIGITS <- 6L
+
+TICS_PER_SECOND <- 10^SPLIT_SECOND_DIGITS
 SECONDS_PER_MINUTE <- 60
 MINUTES_PER_HOUR <- 60
 HOURS_PER_DAY <- 24
 
-SECONDS_PER_HOUR <- MINUTES_PER_HOUR * SECONDS_PER_MINUTE
-SECONDS_PER_DAY <- HOURS_PER_DAY * SECONDS_PER_HOUR
+TICS_PER_MINUTE <- SECONDS_PER_MINUTE * TICS_PER_SECOND
+TICS_PER_HOUR <- MINUTES_PER_HOUR * TICS_PER_MINUTE
+TICS_PER_DAY <- HOURS_PER_DAY * TICS_PER_HOUR
 
 days <- function(x) {
-  trunc(as.numeric(x) / SECONDS_PER_DAY)
+  trunc(x / TICS_PER_DAY)
 }
 
 hours <- function(x) {
-  trunc(as.numeric(x) / SECONDS_PER_HOUR)
+  trunc(x / TICS_PER_HOUR)
 }
 
 hour_of_day <- function(x) {
@@ -18,7 +22,7 @@ hour_of_day <- function(x) {
 }
 
 minutes <- function(x) {
-  trunc(as.numeric(x) / SECONDS_PER_MINUTE)
+  trunc(x / TICS_PER_MINUTE)
 }
 
 minute_of_hour <- function(x) {
@@ -26,7 +30,7 @@ minute_of_hour <- function(x) {
 }
 
 seconds <- function(x) {
-  trunc(as.numeric(x))
+  trunc(x / TICS_PER_SECOND)
 }
 
 second_of_minute <- function(x) {
@@ -34,19 +38,30 @@ second_of_minute <- function(x) {
 }
 
 tics <- function(x) {
-  as.numeric(x)
+  x
 }
 
 tic_of_second <- function(x) {
-  abs(tics(x) - seconds(x))
+  abs(tics(x) - seconds(x) * TICS_PER_SECOND)
 }
 
 decompose <- function(x) {
-  list(
-    sign = x < 0 & !is.na(x),
-    hours = abs(hours(x)),
-    minute_of_hour = minute_of_hour(x),
-    second_of_minute = second_of_minute(x),
-    tics = tic_of_second(x)
+  x <- as.numeric(x) * TICS_PER_SECOND
+
+  # #140
+  xr <- round(x)
+
+  out <- list(
+    sign = xr < 0 & !is.na(xr),
+    hours = abs(hours(xr)),
+    minute_of_hour = minute_of_hour(xr),
+    second_of_minute = second_of_minute(xr),
+    tics = tic_of_second(xr)
   )
+
+  # #140: Make sure zeros are printed
+  fake_zero <- (out$tics == 0) & (xr != x)
+  out$tics[fake_zero] <- 0.25
+
+  out
 }

--- a/R/format.R
+++ b/R/format.R
@@ -7,8 +7,10 @@ format_two_digits <- function(x) {
 }
 
 format_tics <- function(x) {
-  out <- format(x, scientific = FALSE)
-  digits <- max(min(max(nchar(out) - 2), 6), 0)
+  x <- x / TICS_PER_SECOND
+
+  out <- format(x, scientific = FALSE, digits = SPLIT_SECOND_DIGITS + 1L)
+  digits <- max(min(max(nchar(out) - 2), SPLIT_SECOND_DIGITS), 0)
   out <- formatC(x, format = "f", digits = digits)
   gsub("^0", "", out)
 }

--- a/tests/testthat/test-arith.R
+++ b/tests/testthat/test-arith.R
@@ -15,8 +15,8 @@ test_that("arithmetics work", {
 })
 
 test_that("component extraction work", {
-  x <- hms(12.3, 45, 23, 1)
-  expect_equal(tic_of_second(x), 0.3)
+  x <- as.numeric(hms(12.3, 45, 23, 1)) * TICS_PER_SECOND
+  expect_equal(tic_of_second(x), 300000)
   expect_equal(second_of_minute(x), 12)
   expect_equal(minute_of_hour(x), 45)
   expect_equal(hour_of_day(x), 23)
@@ -24,8 +24,8 @@ test_that("component extraction work", {
 })
 
 test_that("component extraction work for negative times", {
-  x <- -hms(12.3, 45, 23, 1)
-  expect_equal(tic_of_second(x), 0.3)
+  x <- as.numeric(-hms(12.3, 45, 23, 1)) * TICS_PER_SECOND
+  expect_equal(tic_of_second(x), 300000)
   expect_equal(second_of_minute(x), 12)
   expect_equal(minute_of_hour(x), 45)
   expect_equal(hour_of_day(x), 23)

--- a/tests/testthat/test-output.R
+++ b/tests/testthat/test-output.R
@@ -50,6 +50,21 @@ test_that("picoseconds (#17)", {
                    c("00:00:01.000000", "00:00:00.000000"))
 })
 
+test_that("picoseconds to the next second (#140)", {
+  expect_identical(format(hms(1 - 1e-6)),
+                   c("00:00:00.999999"))
+  expect_identical(format(hms(1 - 9e-7)),
+                   c("00:00:00.999999"))
+  expect_identical(format(hms(1 - 4e-7)),
+                   c("00:00:01.000000"))
+  expect_identical(format(hms(1 - 1e-10)),
+                   c("00:00:01.000000"))
+  expect_identical(format(hms(1 - 1e-10)),
+                   c("00:00:01.000000"))
+  expect_identical(format(hms(1 - c(1, 1e-10))),
+                   c("00:00:00.000000", "00:00:01.000000"))
+})
+
 test_that("NA", {
   expect_identical(format(hms(NA)),
                    c("NA"))


### PR DESCRIPTION
Fully back-compatible. Times slightly below the full second are rounded up and shown with trailing zeros.

``` r
library(hms)
hms(0.99999)
#> 00:00:00.99999
hms(0.999999)
#> 00:00:00.999999
hms(0.9999999)
#> 00:00:01.000000
hms(0.99999999)
#> 00:00:01.000000
hms(1.00000001)
#> 00:00:01.000000
```

<sup>Created on 2019-03-24 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>

Closes #64.