### PR TITLE
Fix condition expectations in prevision of testthat breaking change

### DIFF
--- a/tests/testthat/test-coercion-deprecated.R
+++ b/tests/testthat/test-coercion-deprecated.R
@@ -1,24 +1,40 @@
 test_that("coercion in", {
-  expect_identical(expect_deprecated(as.hms(0.5 * 86400)), hms(hours = 12))
-  expect_identical(expect_deprecated(as.hms(-0.25 * 86400)), hms(hours = -6))
-  expect_hms_equal(expect_deprecated(as.hms("12:34:56")), hms(56, 34, 12))
-  expect_hms_equal(
-    expect_deprecated(as.hms(strptime("12:34:56", format = "%H:%M:%S", tz = "UTC"), tz = "UTC")),
-    hms(56, 34, 12)
+  expect_deprecated(
+    expect_identical(as.hms(0.5 * 86400), hms(hours = 12))
   )
-  expect_hms_equal(
-    expect_deprecated(as.hms(strptime("12:34:56", format = "%H:%M:%S", tz = "CEST"), tz = "CEST")),
-    hms(56, 34, 12)
+  expect_deprecated(
+    expect_identical(as.hms(-0.25 * 86400), hms(hours = -6))
   )
-  expect_hms_equal(
-    expect_deprecated(as.hms(strptime("12:34:56", format = "%H:%M:%S", tz = "PST8PDT"), tz = "PST8PDT")),
-    hms(56, 34, 12)
+  expect_deprecated(
+    expect_hms_equal(as.hms("12:34:56"), hms(56, 34, 12))
+  )
+  expect_deprecated(
+    expect_hms_equal(
+      as.hms(strptime("12:34:56", format = "%H:%M:%S", tz = "UTC"), tz = "UTC"),
+      hms(56, 34, 12)
+    )
+  )
+  expect_deprecated(
+    expect_hms_equal(
+      as.hms(strptime("12:34:56", format = "%H:%M:%S", tz = "CEST"), tz = "CEST"),
+      hms(56, 34, 12)
+    )
+  )
+  expect_deprecated(
+    expect_hms_equal(
+      as.hms(strptime("12:34:56", format = "%H:%M:%S", tz = "PST8PDT"), tz = "PST8PDT"),
+      hms(56, 34, 12)
+    )
   )
 
   now <- Sys.time()
   now_lt <- as.POSIXlt(now)
-  expect_hms_equal(expect_deprecated(as.hms(now)), hms(now_lt$sec, now_lt$min, now_lt$hour))
-  expect_hms_equal(expect_deprecated(as.hms(now_lt)), as_hms(now))
+  expect_deprecated(
+    expect_hms_equal(as.hms(now), hms(now_lt$sec, now_lt$min, now_lt$hour))
+  )
+  expect_deprecated(
+    expect_hms_equal(as.hms(now_lt), as_hms(now))
+  )
 
   expect_error(expect_deprecated(as.hms(FALSE)))
 })


### PR DESCRIPTION
We are planning a breaking change to the condition expectations in testthat release (see NEWS item in https://github.com/r-lib/testthat/pull/1401). This PR implements a preventive fix that works with and without the breaking change.

There is no hurry to get this fix on CRAN since we are skipping one released version of testthat before going through with the change.
