### PR TITLE
fix: sub-second value parsing accurately

### DIFF
--- a/R/parse.R
+++ b/R/parse.R
@@ -14,7 +14,7 @@
 #' parse_hms("12:34:56")
 #' parse_hms("12:34:56.789")
 parse_hms <- function(x) {
-  as_hms(parse_time(x, format = "%H:%M:%OS"))
+  parse_time(x, format = "%H:%M:%OS")
 }
 
 #' @rdname parse_hms
@@ -24,14 +24,14 @@ parse_hms <- function(x) {
 #' @examples
 #' parse_hm("12:34")
 parse_hm <- function(x) {
-  as_hms(parse_time(x, format = "%H:%M"))
+  parse_time(x, format = "%H:%M")
 }
 
 parse_time <- function(x, format) {
-  difftime(
-    strptime(as.character(x), format = format),
-    strptime("0:0:0", format = "%X"),
-    units = "secs",
-    tz = "UTC"
+  parsed <- strptime(as.character(x), format = format, tz = "UTC")
+  hms(
+    seconds = parsed$sec,
+    minutes = parsed$min,
+    hours = parsed$hour
   )
 }

--- a/tests/testthat/test-parse.R
+++ b/tests/testthat/test-parse.R
@@ -3,6 +3,7 @@ test_that("parse_hms", {
   expect_equal(parse_hms("12:34:56.789"), hms(56.789, 34, 12))
   expect_equal(parse_hms(NA), hms(NA))
   expect_equal(parse_hms(c("12:34:56", NA)), as_hms(c(hms(56, 34, 12), hms(NA))))
+  expect_identical(parse_hms("23:59:59.999999999"), as_hms(86399.999999999))
 })
 
 test_that("parse_hm", {


### PR DESCRIPTION
Fix #127